### PR TITLE
4.x updates - MODS transform and Solr schema.xml

### DIFF
--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -151,7 +151,7 @@
   </xsl:template>
 
   <!-- the following template creates an _ms field for accessCondition+attributes -->
-  <xsl:template match="mods:mods/mods:accessCondition[@type='use and reproduction']">
+  <xsl:template match="mods:mods/mods:accessCondition[@type='use and reproduction']" mode="utk_MODS">
     <field name="utk_mods_accessCondition_ms">
       <xsl:value-of select="normalize-space(concat(.,' ','(','useAndReproduction',')'))"/>
     </field>

--- a/solr-conf/schema.xml
+++ b/solr-conf/schema.xml
@@ -335,7 +335,6 @@
         unknown fields indexed and/or stored by default -->
    <field name="dc.description" type="text_fgs"  indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*" type="text_fgs"  indexed="true"  stored="true" multiValued="true"/>
-   <field name="_version_" type="long" indexed="true" stored="true"/>
 
  </fields>
 


### PR DESCRIPTION
## what does this PR do?

This PR fixes two problems identified by @cdeaneGit: 
1) a missing template mode in slurp_all_MODS_to_solr
2) a duplicated field in Solr's schema.xml that was preventing Solr from starting.
## How Should This Be Tested?
- Make a change to [islandora_transforms/slurp_all_MODS_to_solr.xslt](islandora_transforms/slurp_all_MODS_to_solr.xslt)
  - e.g. change a [field name](https://github.com/CanOfBees/basic-solr-config/blob/4.x-vagrant/islandora_transforms/slurp_all_MODS_to_solr.xslt#L51) from `utk_mods` to `foo_bar`.
- Sync your changes using the utility/methodology of your choice.
- On your islandora_vagrant VM, `$ sudo chown tomcat7:tomcat7` on the updated slurp_all_MODS_to_solr.xslt.
- On your islandora_vagrant VM, restart Tomcat with the following: `$ sudo service tomcat7 restart`
- Update a PID or add a new item to your repository and then update your Solr index.
  - There are a variety of ways to do this; here are two:
    - use the localhost:8080/fedoragsearch/rest interface > select the **updateIndex** link > enter an appropriate PID in the _updateIndex fromPid_ text box and then click _updateIndex fromPid_.
    - ssh into your vagrant VM > run the following `curl` command using the PID of the updated item: `curl -u fedoraAdmin:fedoraAdmin -X GET "http://localhost:8080/fedoragsearch/rest?operation=updateIndex&action=fromPid&value=$YOUR_PID"`
- Query the Solr index from your browser: `http://localhost:8080/solr/collection1/select?q=%22$YOUR_PID_HERE%22&fl=PID%2Cutk_mods_*&df=PID&wt=xml&indent=true`. **Note:** depending on your browser you may need to escape the `:` in your PID; e.g. `islandora:3` vs `islandora%3A3`.
## Interested Parties
